### PR TITLE
fix(plugin-cert): use to openshift-kube-conformance as pre-flight

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -4,13 +4,40 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
+echo "##> "
+echo "#> Starting destroy flow..."
+
 sonobuoy delete --wait
 
 sleep 5
 # Check if there's 'e2e-' namespaces (it should be deleted when starting new tests)
 # TODO: Is there any other reuqirement to simulate a clean installation to start
 #  running the suite of tests instead of providing a new cluster installation?
-for project in $(oc get projects |awk '{print$1}' |grep ^e2e |sort -u || true); do
+echo "Removing NSs created by openshift-tests"
+mapfile -t NS_DELETE < <(oc get projects |awk '{print$1}' |grep ^e2e- |sort -u || true)
+for project in "${NS_DELETE[@]}"; do
     echo "Stale namespace was found: [${project}], removing..."
-    oc delete project "${project}"
+    oc delete project "${project}" || true
 done
+
+# Projects created by k8s-e2e conformance tests.
+# echo "Removing NSs created by kube-conformance"
+# mapfile -t NS_DELETE < <(oc get projects |awk '{print$1}' |grep -P '^(statefulset-[\d+].*)|(proxy-[\d+].*)|(cronjob-[\d+].*)|(kubectl-[\d+].*)|(replication-controller-[\d+].*)|(sched-preemption-[\d+].*)|(taint-multiple-pods-[\d+].*)' || true)
+
+sleep 10;
+echo "Removing non-openshift NS (don't do it on the final release =] )"
+mapfile -t NS_DELETE < <(oc get projects |awk '{print$1}' |grep -vP '^(NAME)|(openshift)|(kube-(system|public|node-lease))|(default)' |sort -u || true)
+for project in "${NS_DELETE[@]}"; do
+    echo "Stale namespace was found: [${project}], removing..."
+    oc delete project "${project}" || true
+done
+
+echo "Removing status file"
+st_file="/tmp/sonobuoy-status.json"
+rm ${st_file} || true
+
+echo "Restoring privileged environment..."
+oc adm policy remove-scc-from-group anyuid system:authenticated system:serviceaccounts || true
+oc adm policy remove-scc-from-group privileged system:authenticated system:serviceaccounts  || true
+
+echo "Destroy Done!"

--- a/report.sh
+++ b/report.sh
@@ -4,6 +4,9 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
+echo "##> "
+echo "#> Starting Report flow..."
+
 tmp_dir="$(dirname "$0")/.tmp"
 result_file=$(cat "${tmp_dir}"/latest-result.txt)
 result_dir=${tmp_dir}/results
@@ -11,7 +14,7 @@ result_dir=${tmp_dir}/results
 test -d "${result_dir}" && rm -rf "${result_dir:-./}"/*
 test -d "${result_dir}" || mkdir -p "$result_dir"
 
-plugin_names=()
+plugin_names=("openshift-kube-conformance")
 for i in $(seq 1 3); do
   plugin_names+=("openshift-provider-cert-level$i")
 done
@@ -23,7 +26,7 @@ if [[ ! -f "$result_file" ]]; then
   exit 1
 fi
 
-echo "Inspecting latest result file: ${result_file}"
+echo -e "\n#>\t Inspecting latest result file: ${result_file}"
 
 echo "Extracting sonobuoy results..."
 
@@ -34,9 +37,9 @@ for plugin_name in "${plugin_names[@]}"; do
   tar -C results -xvf ./"${result_file}" plugins/"${plugin_name}" || true
 done
 
-echo "Getting result feedback..."
+echo -e "\n#> Getting result feedback..."
 
-echo "Getting tests count by status for each Level:"
+echo -e "\n#>> Getting tests count by status for each Level:"
 
 statusess="passed skipped failed";
 for plugin_name in "${plugin_names[@]}"; do
@@ -47,7 +50,7 @@ for plugin_name in "${plugin_names[@]}"; do
     done;
 done
 
-echo -e "\nGetting 'failed' test names by Level:"
+echo -e "\n#>> Getting 'failed' test names by Level:"
 
 statusess="failed";
 for st in $statusess; do
@@ -58,7 +61,7 @@ for st in $statusess; do
     done;
 done
 
-echo -e "\nLooking for plugins global error's files [errors/global/error.json]:"
+echo -e "\n#>> Looking for plugins global error's files [errors/global/error.json]:"
 
 for plugin_name in "${plugin_names[@]}"; do
     test -f results/plugins/"${plugin_name}"/errors/global/error.json || continue

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,7 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
+echo "##> "
 echo "Starting OpenShift Provider Certification Tool..."
 
 # Check if there's sonobuoy environment: should fail
@@ -21,55 +22,55 @@ for project in $(oc get projects |awk '{print$1}' |grep ^e2e |sort -u || true); 
     oc delete project "${project}" || true
 done
 
+echo "Ensuring the Tool will run in the privileged environment..."
+oc adm policy add-scc-to-group anyuid system:authenticated system:serviceaccounts
+oc adm policy add-scc-to-group privileged system:authenticated system:serviceaccounts
+
 echo "Running OpenShift Provider Certification Tool..."
 sleep 5
 
 # Do not use timeout=0:
 # https://github.com/mtulio/openshift-provider-certification/issues/17
 PLUGIN_TIMEOUT=43200
+
 sonobuoy run \
     --dns-namespace openshift-dns \
     --dns-pod-labels=dns.operator.openshift.io/daemonset-dns=default \
     --timeout ${PLUGIN_TIMEOUT} \
-    --plugin tools/plugins/level-0-kube-conformance.yaml \
+    --plugin tools/plugins/openshift-kube-conformance.yaml \
     --plugin tools/plugins/openshift-provider-cert-level-1.yaml \
     --plugin tools/plugins/openshift-provider-cert-level-2.yaml \
     --plugin tools/plugins/openshift-provider-cert-level-3.yaml
 
-sleep 5 # waiting to leave from 'Pending' state
-echo "$(date)> The certification tool is running, statuses will be reported every minute..."
-sonobuoy status
+# Show custom status
+st_file="/tmp/sonobuoy-status.json"
+update_status() {
+    sonobuoy status --json > "${st_file}" 2>/dev/null || true
+}
 
-cnt=0
-while true; do
-    if [[ "$(sonobuoy status --json |jq -r .status)" != "running" ]]; then
-        break
-    fi
-    cnt=$(( cnt + 1 ))
-    if [[ $(( cnt % 3 )) -eq 0 ]]; then
-        echo -e "\n\n$(date)> Sonobuoy is still running..."
-        sonobuoy status
-    fi
-    # Detailed status
-    st_file="/tmp/sonobuoy-status.json"
-    sonobuoy status --json > "${st_file}"
-    printf "\n\nGlobal Status: %s" "$(jq -r '.status // "Unknown"' ${st_file})"
+show_status() {
+    update_status
+    printf "\n\n$(date)> Global Status: %s" "$(jq -r '.status // "Unknown"' ${st_file})"
     printf "\n%-30s | %-10s | %-10s | %-25s | %-50s" \
             "JOB_NAME" "STATUS" "RESULTS" "PROGRESS" "MESSAGE"
-    for plugin_name in $(jq -r '.plugins[].plugin' /tmp/sonobuoy-status.json |sort); do
+    for plugin_name in $(jq -r '.plugins[].plugin' ${st_file} |sort); do
         pl_status=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\").status" "${st_file}")
         pl_result=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\")[\"result-status\"]" "${st_file}" | tr -d '\n')
 
         pl_prog_total=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\").progress.total // \"\"" "${st_file}" | tr -d '\n')
         pl_prog_comp=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\").progress.completed // \"\"" "${st_file}" | tr -d '\n')
         pl_prog_failed=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\").progress.failures|length" "${st_file}" | tr -d '\n')
-        pl_progress="${pl_prog_comp}/${pl_prog_total} (${pl_prog_failed} failures)"
 
-        pl_count_fail=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\")[\"result-counts\"].failed" "${st_file}" | tr -d '\n')
-        pl_count_pass=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\")[\"result-counts\"].passed" "${st_file}" | tr -d '\n')
+        pl_progress=""
+        if [[ -n "${pl_prog_total}" ]]; then
+            pl_progress="${pl_prog_comp}/${pl_prog_total} (${pl_prog_failed} failures)"
+        fi
+
+        pl_count_fail=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\")[\"result-counts\"].failed // 0" "${st_file}" | tr -d '\n')
+        pl_count_pass=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\")[\"result-counts\"].passed // 0" "${st_file}" | tr -d '\n')
 
         if [[ "${pl_status}" == "running" ]]; then
-            pl_msg=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\") |.progress.msg // \"N/A\"" "${st_file}" | tr -d '\n')
+            pl_msg=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\") |.progress.msg // \"\"" "${st_file}" | tr -d '\n')
         elif [[ "${pl_result}" == "" ]]; then
             pl_msg="waiting post-processor..."
         else
@@ -80,17 +81,58 @@ while true; do
                 "${plugin_name}" "${pl_status}" "${pl_result}" \
                 "${pl_progress}" "${pl_msg}"
     done
+}
 
+show_results_processor() {
+    update_status
+    printf "\n\n$(date)> Global Status: %s" "$(jq -r '.status // "Unknown"' ${st_file})"
+    printf "\n%-30s | %-10s | %-10s | %-50s" \
+            "JOB_NAME" "STATUS" "RESULTS" "PROCESSOR RESULTS"
+    for plugin_name in $(jq -r '.plugins[].plugin' ${st_file} |sort); do
+        pl_status=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\").status" "${st_file}")
+        pl_result=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\")[\"result-status\"]" "${st_file}" | tr -d '\n')
+
+        pl_count_fail=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\")[\"result-counts\"].failed" "${st_file}" | tr -d '\n')
+        pl_count_pass=$(jq -r ".plugins[] | select (.plugin==\"${plugin_name}\")[\"result-counts\"].passed" "${st_file}" | tr -d '\n')
+
+        pl_msg="Total tests processed: $(echo "$pl_count_pass + $pl_count_fail "|bc) (${pl_count_pass} pass / ${pl_count_fail} failed)"
+
+        printf "\n%-30s | %-10s | %-10s | %-50s" \
+                "${plugin_name}" "${pl_status}" \
+                "${pl_result}" "${pl_msg}"
+    done
+}
+
+sleep 5 # waiting to leave from 'Pending' state
+echo "$(date)> The certification tool is running, statuses will be reported every minute..."
+sonobuoy status
+
+cnt=0
+while true; do
+    update_status
+    if [[ "$(jq -r .status ${st_file})" != "running" ]]; then
+        break
+    fi
+    show_status
     sleep 10
 done
 
-echo -e "\n$(date)> Test suite has finished."
-sonobuoy status
+show_status
+echo -e "\n\n$(date)> Jobs has finished."
+sleep 5
+show_results_processor
 
-echo -e "\nWaiting the results to be processed..."
+#TODO(): Create a fn show_results w/ custom fields of processor,
+# w/o PROGRESS field.
+#TODO(): there's a bug on kube-conformance suite with is crashing
+# the plugin, resulting in empty junit files. Report-progress should
+# report crashs like that w/ some insights on MSG aggregator field.
+
+echo -e "\nWaiting the post-processor to collect the results..."
 cnt=0
 while true; do
-    if [[ "$(sonobuoy status --json |jq -r .status)" != "post-processing" ]]; then
+    update_status
+    if [[ "$(jq -r .status ${st_file})" != "post-processing" ]]; then
         break
     fi
     cnt=$(( cnt + 1 ))
@@ -102,7 +144,7 @@ while true; do
     sleep 30
 done
 
-echo -e "\nCollecting results..."
+echo -e "\n\nCollecting results..."
 sleep 10
 
 set +o errexit
@@ -117,8 +159,6 @@ while ${download_failed}; do
     # TODO[2](asap): The filename could be set for 'retrieve' option,
     # so it can be an work arround while [1] is not fixed.
     if [[ ${RC} -eq 0 ]]; then
-        #echo "One or more errors found to retrieve results"
-        #exit ${RC}
         download_failed=false
     fi
     retries=$(( retries + 1 ))

--- a/tools/openshift-provider-cert-plugin/executor.sh
+++ b/tools/openshift-provider-cert-plugin/executor.sh
@@ -37,7 +37,7 @@ if [[ -n "${CERT_TEST_FILE:-}" ]]; then
             --junit-dir "${RESULTS_DIR}" \
             -f "${CERT_TEST_FILE}" \
             | tee -a "${RESULTS_PIPE}" || true
-        os_log_info "openshift-tests finished"
+        os_log_info "openshift-tests finished[$?]"
     else
         os_log_info "the file provided has no tests. Sending progress and finish executor...";
         echo "(0/0/0)" > "${RESULTS_PIPE}"
@@ -45,7 +45,7 @@ if [[ -n "${CERT_TEST_FILE:-}" ]]; then
 
 # Filter by string pattern from 'all' tests
 elif [[ -n "${CUSTOM_TEST_FILTER_STR:-}" ]]; then
-    os_log_info "#executor>Generating a filter [${CUSTOM_TEST_FILTER_STR}]..."
+    os_log_info "Generating a filter [${CUSTOM_TEST_FILTER_STR}]..."
     openshift-tests run --dry-run all \
         | grep "${CUSTOM_TEST_FILTER_STR}" \
         | openshift-tests run -f - \
@@ -55,11 +55,16 @@ elif [[ -n "${CUSTOM_TEST_FILTER_STR:-}" ]]; then
 # Set E2E_SUITE on plugin manifest to change it (unset CERT_LEVEL).
 else
     suite="${E2E_SUITE:-kubernetes/conformance}"
-    os_log_info "#executor>Running default execution for openshift-tests suite [${suite}]..."
+    os_log_info "Running default execution for openshift-tests suite [${suite}]..."
+    #TODO: Improve the visibility when this execution fails.
+    # - Save the stdout to a custom file
+    # - Create a custom Junit file w/ failed test, and details about the
+    #   failures. Maybe the entire b64 of stdout as failure description field.
     openshift-tests run \
         --junit-dir "${RESULTS_DIR}" \
         "${suite}" \
         | tee -a "${RESULTS_PIPE}" || true
+    os_log_info "openshift-tests finished[$?]"
 fi
 
 os_log_info "Plugin executor finished. Result[$?]";

--- a/tools/openshift-provider-cert-plugin/global_env.sh
+++ b/tools/openshift-provider-cert-plugin/global_env.sh
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
 
-declare -x PLUGIN_BLOCKED_BY
+declare -gx PLUGIN_BLOCKED_BY
 PLUGIN_BLOCKED_BY=()
 
-declare -rx CERT_TESTS_DIR="./tests/${OPENSHIFT_VERSION:-"v4.10"}"
+declare -grx CERT_TESTS_DIR="./tests/${OPENSHIFT_VERSION:-"v4.10"}"
 
-declare -x CERT_TEST_FILE
-CERT_TEST_FILE=""
+declare -gx CERT_LEVEL
+declare -gx CERT_TEST_FILE
+declare -gx CERT_TEST_FILE_COUNT
 
-declare -Ax PROGRESS
-declare -rx PROGRESS_URL="http://127.0.0.1:8099/progress"
+declare -gAx PROGRESS
+declare -grx PROGRESS_URL="http://127.0.0.1:8099/progress"
+declare -grx SONOBUOY_BIN="./sonobuoy"
+declare -grx STATUS_FILE="/tmp/sonobuoy-status.json"
+declare -grx STATUS_UPDATE_INTERVAL_SEC="5"
 
-declare -rx RESULTS_DIR="${RESULTS_DIR:-/tmp/sonobuoy/results}"
-declare -rx RESULTS_DONE_NOTIFY="${RESULTS_DIR}/done"
-declare -rx RESULTS_PIPE="${RESULTS_DIR}/status_pipe"
-declare -rx RESULTS_SCRIPTS="${RESULTS_DIR}/plugin-scripts"
+declare -grx RESULTS_DIR="${RESULTS_DIR:-/tmp/sonobuoy/results}"
+declare -grx RESULTS_DONE_NOTIFY="${RESULTS_DIR}/done"
+declare -grx RESULTS_PIPE="${RESULTS_DIR}/status_pipe"
+declare -grx RESULTS_SCRIPTS="${RESULTS_DIR}/plugin-scripts"
 
-declare -rx KUBECONFIG="${RESULTS_DIR}/kubeconfig"
-declare -rx SA_CA_PATH="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-declare -rx SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
+declare -grx KUBECONFIG="${RESULTS_DIR}/kubeconfig"
+declare -grx SA_CA_PATH="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+declare -grx SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
 

--- a/tools/openshift-provider-cert-plugin/global_fn.sh
+++ b/tools/openshift-provider-cert-plugin/global_fn.sh
@@ -22,33 +22,73 @@ create_dependencies_plugin() {
     test -p "${RESULTS_PIPE}" || mkfifo "${RESULTS_PIPE}"
 }
 
-set_config() {
+init_config() {
+    os_log_info_local "[init_config]"
     if [[ -z "${CERT_LEVEL:-}" ]]
     then
-        os_log_info "Empty CERT_LEVEL. It should be defined. Exiting..."
+        os_log_info_local "Empty CERT_LEVEL. It should be defined. Exiting..."
         exit 1
+
+    # openshift-kube-conformance (kube-conformance running w/ openshift-tests)
+    elif [[ "${CERT_LEVEL:-}" == "0" ]]
+    then
+        CERT_TEST_FILE=""
+        PLUGIN_BLOCKED_BY=()
 
     elif [[ "${CERT_LEVEL:-}" == "1" ]]
     then
-        os_log_info_local "Setting config for CERT_LEVEL=[${CERT_LEVEL:-}]"
-        export CERT_TEST_FILE="${CERT_TESTS_DIR}/level1.txt"
-        export PLUGIN_BLOCKED_BY+=("kube-conformance")
+        CERT_TEST_FILE="${CERT_TESTS_DIR}/level1.txt"
+        PLUGIN_BLOCKED_BY+=("openshift-kube-conformance")
 
     elif [[ "${CERT_LEVEL:-}" == "2" ]]
     then
         os_log_info_local "Setting config for CERT_LEVEL=[${CERT_LEVEL:-}]" 
-        export CERT_TEST_FILE="${CERT_TESTS_DIR}/level2.txt"
-        export PLUGIN_BLOCKED_BY+=("openshift-provider-cert-level1")
+        CERT_TEST_FILE="${CERT_TESTS_DIR}/level2.txt"
+        PLUGIN_BLOCKED_BY+=("openshift-provider-cert-level1")
 
     elif [[ "${CERT_LEVEL:-}" == "3" ]]
     then
         os_log_info_local "Setting config for CERT_LEVEL=[${CERT_LEVEL:-}]"
-        export CERT_TEST_FILE="${CERT_TESTS_DIR}/level3.txt"
-        export PLUGIN_BLOCKED_BY+=("openshift-provider-cert-level2")
+        CERT_TEST_FILE="${CERT_TESTS_DIR}/level3.txt"
+        PLUGIN_BLOCKED_BY+=("openshift-provider-cert-level2")
 
     else
-        os_log_info "Unknow value for CERT_LEVEL=[${CERT_LEVEL:-}]"
+        os_log_info "[init_config] Unknow value for CERT_LEVEL=[${CERT_LEVEL:-}]"
         exit 1
     fi
+
+    os_log_info_local "Level's specific finished. Setting discoverying total tests to run..."
+    CERT_TEST_FILE_COUNT=0
+    if [[ -n "${CERT_TEST_FILE:-}" ]]; then
+        CERT_TEST_FILE_COUNT="$(wc -l "${CERT_TEST_FILE}" |cut -f 1 -d' ' |tr -d '\n')"
+    fi
+
+    os_log_info_local "Setup config done"
 }
-export -f set_config
+export -f init_config
+
+#
+# Status scraper collects the results of Sonobuoy plugins
+# The scraper will keep the status file STATUS_FILE consumed
+# by different components on this container (waiter, progress reporter).
+#
+start_status_collector() {
+    os_log_info_local "Starting sonobuoy status collector..."
+    while true;
+    do
+        ${SONOBUOY_BIN} status --json 2>/dev/null > "${STATUS_FILE}"
+        sleep "${STATUS_UPDATE_INTERVAL_SEC}"
+    done
+}
+export -f start_status_collector
+
+wait_status_file() {
+    while true;
+    do
+        os_log_info_local "Check if status file exists=[${STATUS_FILE}]"
+        test -f "${STATUS_FILE}" && break
+        sleep "${STATUS_UPDATE_INTERVAL_SEC}"
+    done
+    os_log_info_local "Status file exists!"
+}
+export -f wait_status_file

--- a/tools/openshift-provider-cert-plugin/global_fn.sh
+++ b/tools/openshift-provider-cert-plugin/global_fn.sh
@@ -58,7 +58,7 @@ init_config() {
     fi
 
     os_log_info_local "Level's specific finished. Setting discoverying total tests to run..."
-    CERT_TEST_FILE_COUNT=0
+    export CERT_TEST_FILE_COUNT=0
     if [[ -n "${CERT_TEST_FILE:-}" ]]; then
         CERT_TEST_FILE_COUNT="$(wc -l "${CERT_TEST_FILE}" |cut -f 1 -d' ' |tr -d '\n')"
     fi

--- a/tools/openshift-provider-cert-plugin/report-progress.sh
+++ b/tools/openshift-provider-cert-plugin/report-progress.sh
@@ -18,6 +18,41 @@ os_log_info_local() {
     echo "$(date +%Y%m%d-%H%M%S)> [report] $*"
 }
 
+init_config
+
+declare -g PIDS_LOCAL
+PIDS_LOCAL=()
+
+declare -g PROGRESS
+PROGRESS=( ["completed"]=0 ["total"]=${CERT_TEST_FILE_COUNT} ["failures"]="" ["msg"]="" )
+
+
+wait_progress_api() {
+    ADDR_IP="127.0.0.1"
+    ADDR_PORT="8099"
+    os_log_info_local "waiting for sonobuoy-worker service is ready..."
+    while true
+    do
+        test "$(nc -z -v ${ADDR_IP} ${ADDR_PORT} >/dev/null 2>&1; echo $?)" -eq 0 && break
+        sleep 1
+    done
+    os_log_info_local "sonobuoy-worker progress api[${PROGRESS_URL}] is ready."
+}
+
+update_progress() {
+    # Reporting progress to sonobuoy progress API
+    component_caller="${1:-"update_progress"}"; shift
+    msg="${1:-"N/D"}"; shift || true
+    body="{
+        \"completed\":${PROGRESS["completed"]},
+        \"total\":${PROGRESS["total"]},
+        \"failures\":[${PROGRESS["failures"]}],
+        \"msg\":\"${msg}\"
+    }"
+    os_log_info_local "Sending report payload [${component_caller}]: ${body}"
+    curl -s "${PROGRESS_URL}" -d "${body}" || true
+}
+
 wait_pipe_exists() {
     os_log_info_local "waiting for pipe creation..."
     while true
@@ -33,8 +68,8 @@ watch_plugin_done() {
     while true; do
         if [[ -f "${RESULTS_DONE_NOTIFY}" ]]
         then
-            echo "Sonobuoy done detected [waiter]" |tee -a "${RESULTS_PIPE}"
-            exit 0
+            echo "Sonobuoy done detected [done wacther]" |tee -a "${RESULTS_PIPE}"
+            return
         fi
         sleep 1
     done
@@ -47,35 +82,64 @@ watch_dependency_done() {
         os_log_info_local "waiting for plugin [${plugin_name}]"
         timeout_checks=0
         timeout_count=100
+        last_count=0
         while true;
         do
             if [[ -f "${RESULTS_DONE_NOTIFY}" ]]
             then
-                echo "Sonobuoy done detected [waiter watch]" |tee -a "${RESULTS_PIPE}"
-                exit 0
+                echo "Sonobuoy done detected [dependency wacther]" |tee -a "${RESULTS_PIPE}"
+                return
             fi
 
-            ./sonobuoy status --json > /tmp/sonobuoy-status.json 2>/dev/null
-            plugin_status=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.status // \"\"" /tmp/sonobuoy-status.json)
+            plugin_status=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.status // \"\"" "${STATUS_FILE}")
             if [[ "${plugin_status}" == "complete" ]]; then
                 echo "Plugin[${plugin_name}] with status[${plugin_status}] is completed!"
                 break
             fi
-            count=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.progress.completed // \"0\"" /tmp/sonobuoy-status.json)
-            total=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.progress.total // \"0\"" /tmp/sonobuoy-status.json)
+            count=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.progress.completed // 0" "${STATUS_FILE}")
+            total=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.progress.total // \"0\"" "${STATUS_FILE}")
             remaining=$(( total - count ))
             test $remaining -ge 0 && remaining=$(( (total - count) * (-1) ))
 
-            waiting_for_msg="status=waiting-for-plugin=${plugin_name}=(0/${remaining}/0)=[${timeout_checks}/${timeout_count}]"
+            blocker_msg=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.progress.msg // \"\"" "${STATUS_FILE}")
+            # Dependency plugin is also waiting
+            if [[ "${blocker_msg}" =~ "status=waiting-for" ]]; then
+                state_blocking="blocked-by"
+            # Dependency plugin is also blocked
+            elif [[ "${blocker_msg}" =~ "status=blocked-by" ]]; then
+                state_blocking="blocked-by"
+            else
+                state_blocking="waiting-for"
+            fi
+            msg="status=${state_blocking}=${plugin_name}=(0/${remaining}/0)=[${timeout_checks}/${timeout_count}]"
+
+            # Reporting progress to sonobuoy progress API
             body="{
                 \"completed\":0,
-                \"total\":0,
+                \"total\":${CERT_TEST_FILE_COUNT},
                 \"failures\":[],
-                \"msg\":\"${waiting_for_msg}\"
+                \"msg\":\"${msg}\"
             }"
-            os_log_info_local "Sending report payload: ${body}"
+            os_log_info_local "Sending report payload [dep-checker]: ${body}"
             curl -s "${PROGRESS_URL}" -d "${body}"
 
+            # Timeout checker
+            ## 1. Dont block by long running plugins (only non-updated)
+            ## Timeout checks will increase only when previous jobs got stuck,
+            ## otherwise it will be reset. It can avoid the plugin run infinitely,
+            ## also avoid to set low timeouts for 'unknown' exec time on dependencies.
+            if [[ ${count} -gt ${last_count} ]]; then
+                timeout_checks=0
+                sleep 10
+                continue
+            fi
+            # dont run timeouts for blockers plugins
+            if [[ "${blocker_msg}" =~ "status=blocked-by" ]]; then
+                timeout_checks=0
+                sleep 10
+                continue
+            fi
+            last_count=${count}
             timeout_checks=$(( timeout_checks + 1 ))
             if [[ ${timeout_checks} -eq ${timeout_count} ]]; then
                 echo "Timeout waiting condition 'complete' for plugin[${plugin_name}]."
@@ -88,11 +152,10 @@ watch_dependency_done() {
     os_log_info_local "[plugin dependencies] Finished!"
 }
 
+# Main function to report progress
 report_sonobuoy_progress() {
     local has_update
-    PROGRESS+=( ["completed"]=0 ["total"]=0 ["failures"]="" ["msg"]="" )
     has_update=0
-
     while true
     do
         # Watch sonobuoy done file
@@ -128,7 +191,7 @@ report_sonobuoy_progress() {
                     \"failures\":[${PROGRESS["failures"]}],
                     \"msg\":\"status=running\"
                 }"
-                os_log_info_local "Sending report payload: ${body}"
+                os_log_info_local "Sending report payload [updater]: ${body}"
                 curl -s -d "${body}" "${PROGRESS_URL}"
                 has_update=0;
             fi
@@ -138,13 +201,28 @@ report_sonobuoy_progress() {
     done
 }
 
-set_config
-os_log_info_local "PLUGIN_BLOCKED_BY=${PLUGIN_BLOCKED_BY[*]}"
+#
+# Main
+#
+
+start_status_collector &
+wait_status_file
+
+wait_progress_api
+update_progress "init" "status=initializing";
 
 wait_pipe_exists
+
 watch_plugin_done &
+PIDS_LOCAL+=($!)
+
 watch_dependency_done &
+PIDS_LOCAL+=($!)
+
 report_sonobuoy_progress
+
+os_log_info_local "Waiting for PIDs [finalizer]: ${PIDS_LOCAL[*]}"
+wait "${PIDS_LOCAL[@]}"
 
 body="{
     \"completed\":${PROGRESS["completed"]},
@@ -152,7 +230,7 @@ body="{
     \"failures\":[${PROGRESS["failures"]}],
     \"msg\":\"status=report-progress-finished\"
 }"
-os_log_info_local "Sending report payload: ${body}"
+os_log_info_local "Sending report payload [finalizer]: ${body}"
 curl -s -d "${body}" "${PROGRESS_URL}" || true
 
 os_log_info_local "all done"

--- a/tools/openshift-provider-cert-plugin/runner.sh
+++ b/tools/openshift-provider-cert-plugin/runner.sh
@@ -20,7 +20,7 @@ os_log_info_local() {
 os_log_info_local "Starting plugin..."
 
 create_dependencies_plugin
-set_config
+init_config
 
 # Notify sonobuoy worker with e2e results (junit)
 # https://github.com/vmware-tanzu/sonobuoy/blob/main/site/content/docs/main/plugins.md#plugin-result-types
@@ -59,10 +59,10 @@ EOF
 }
 trap sig_handler_save_results EXIT
 
-# TODO(serial-execution): add a wait flow to lock execution while
-# lower 'level' did not finished (serial execution). Running suites in parallel
-# may impact on the results (mainly in monitoring).
-# https://github.com/mtulio/openshift-provider-certification/issues/2
+os_log_info_local "starting sonobuoy status scraper..."
+start_status_collector &
+wait_status_file
+
 os_log_info_local "starting waiter..."
 "$(dirname "$0")"/wait-plugin.sh
 

--- a/tools/openshift-provider-cert-plugin/wait-plugin.sh
+++ b/tools/openshift-provider-cert-plugin/wait-plugin.sh
@@ -9,37 +9,62 @@ os_log_info_local() {
     os_log_info "$(date +%Y%m%d-%H%M%S)> [waiter] $*"
 }
 
-os_log_info_waiter "Starting Level[${CERT_LEVEL:-}]..."
-set_config
+os_log_info_local "Starting Level[${CERT_LEVEL:-}]..."
+init_config
 
 os_log_info_local "Checking if there's plugins blocking Level${CERT_LEVEL:-} execution..."
 if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
     os_log_info_local "Level${CERT_LEVEL:-} plugin is blocked by: [${PLUGIN_BLOCKED_BY[*]}]"
     for pod_label in "${PLUGIN_BLOCKED_BY[@]}"; do
-        os_log_info_waiter "Waiting running pod-label: ${pod_label}"
+        os_log_info_local "Waiting for pod running with label: ${pod_label}"
         kubectl wait \
             --timeout=10m \
             --for=condition=ready pod \
             -l sonobuoy-plugin="${pod_label}"
     done
 
-    os_log_info_local "Resources ready! Waiting for Level[${CERT_LEVEL:-}]'s plugins is completed..."
+    os_log_info_local "Resource(s) ready! Waiting for Level[${CERT_LEVEL:-}]'s plugins be completed..."
     for plugin_name in "${PLUGIN_BLOCKED_BY[@]}"; do
         os_log_info_local "Waiting 'completed' condition for pod: ${plugin_name}"
         
         # Wait until sonobuoy job is completed
         timeout_checks=0
         timeout_count=100
+        last_count=0
         while true;
         do
-            plugin_status=$(./sonobuoy status --json \
-                | jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.status // \"\"")
+            plugin_status=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.status // \"\"" "${STATUS_FILE}")
+
             os_log_info_local "Plugin[${plugin_name}] with status[${plugin_status}]..."
-            os_log_info_local "$(./sonobuoy status --json)"
+            os_log_info_local "$(cat "${STATUS_FILE}")"
             if [[ "${plugin_status}" == "complete" ]]; then
                 os_log_info_local "Plugin[${plugin_name}] with status[${plugin_status}] is completed!"
                 break
             fi
+
+            # Timeout checker
+            ## 1. Dont block by long running plugins (only non-updated)
+            ## Timeout checks will increase only when previous jobs got stuck,
+            ## otherwise it will be reset. It can avoid the plugin run infinitely,
+            ## also avoid to set low timeouts for 'unknown' exec time on dependencies.
+            count=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.progress.completed // 0" "${STATUS_FILE}")
+            if [[ ${count} -gt ${last_count} ]]; then
+                timeout_checks=0
+                sleep 10
+                continue
+            fi
+            ## 2. Dont get stuck for blocked plugins (which is already waiting for deps)
+            blocker_msg=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.progress.msg // \"\"" "${STATUS_FILE}")
+            if [[ "${blocker_msg}" =~ "status=blocked-by" ]]; then
+                timeout_checks=0
+                sleep 10
+                continue
+            elif [[ "${blocker_msg}" =~ "status=waiting-for" ]]; then
+                timeout_checks=0
+                sleep 10
+                continue
+            fi
+            last_count=${count}
             timeout_checks=$(( timeout_checks + 1 ))
             if [[ ${timeout_checks} -eq ${timeout_count} ]]; then
                 os_log_info_local "Timeout waiting condition 'complete' for plugin[${plugin_name}]."

--- a/tools/plugins/level-0-kube-conformance.yaml
+++ b/tools/plugins/level-0-kube-conformance.yaml
@@ -25,7 +25,7 @@ spec:
   - name: E2E_FOCUS
     value: \[Conformance\]
   - name: E2E_PARALLEL
-    value: "false"
+    value: "true"
   - name: E2E_USE_GO_RUNNER
     value: "true"
   - name: RESULTS_DIR

--- a/tools/plugins/openshift-kube-conformance.yaml
+++ b/tools/plugins/openshift-kube-conformance.yaml
@@ -1,0 +1,36 @@
+podSpec:
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+  containers:
+    - name: report-progress
+      image: quay.io/mrbraga/openshift-tests-provider-cert:latest
+      imagePullPolicy: Always
+      command: ["./report-progress.sh"]
+      volumeMounts:
+      - mountPath: /tmp/sonobuoy/results
+        name: results
+      env:
+        - name: CERT_LEVEL
+          value: "0"
+
+sonobuoy-config:
+  driver: Job
+  plugin-name: openshift-kube-conformance
+  result-format: junit
+spec:
+  name: plugin
+  image: quay.io/mrbraga/openshift-tests-provider-cert:latest
+  imagePullPolicy: Always
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/sonobuoy/results
+    name: results
+  env:
+    - name: CERT_LEVEL
+      value: "0"


### PR DESCRIPTION
Issues targeted on this PR:
- [x] 1. Replace the sonobuoy (native) plugin e2e (kube-conformance) with `openshift-tests` `kubernetes/conformance` suite which is much more performant
- [x] 2. support pre-flight plugin targeted as `CERT_LEVEL=0` 
- [x] 3. Fix progress report message to improve the feedback on CLI
- [x] 4. Fix `openshift-tests` crashing before finish the execution of `kube-conformance` suite