### PR TITLE
fix(plugin-cert): report-progress timeout for blocked plugins

### DIFF
--- a/tools/openshift-provider-cert-plugin/global_env.sh
+++ b/tools/openshift-provider-cert-plugin/global_env.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+declare -gx PLUGIN_NAME
 declare -gx PLUGIN_BLOCKED_BY
 PLUGIN_BLOCKED_BY=()
 

--- a/tools/openshift-provider-cert-plugin/global_fn.sh
+++ b/tools/openshift-provider-cert-plugin/global_fn.sh
@@ -32,22 +32,26 @@ init_config() {
     # openshift-kube-conformance (kube-conformance running w/ openshift-tests)
     elif [[ "${CERT_LEVEL:-}" == "0" ]]
     then
+        PLUGIN_NAME="openshift-kube-conformance"
         CERT_TEST_FILE=""
         PLUGIN_BLOCKED_BY=()
 
     elif [[ "${CERT_LEVEL:-}" == "1" ]]
     then
+        PLUGIN_NAME="openshift-provider-cert-level1"
         CERT_TEST_FILE="${CERT_TESTS_DIR}/level1.txt"
         PLUGIN_BLOCKED_BY+=("openshift-kube-conformance")
 
     elif [[ "${CERT_LEVEL:-}" == "2" ]]
     then
+        PLUGIN_NAME="openshift-provider-cert-level2"
         os_log_info_local "Setting config for CERT_LEVEL=[${CERT_LEVEL:-}]" 
         CERT_TEST_FILE="${CERT_TESTS_DIR}/level2.txt"
         PLUGIN_BLOCKED_BY+=("openshift-provider-cert-level1")
 
     elif [[ "${CERT_LEVEL:-}" == "3" ]]
     then
+        PLUGIN_NAME="openshift-provider-cert-level3"
         os_log_info_local "Setting config for CERT_LEVEL=[${CERT_LEVEL:-}]"
         CERT_TEST_FILE="${CERT_TESTS_DIR}/level3.txt"
         PLUGIN_BLOCKED_BY+=("openshift-provider-cert-level2")

--- a/tools/openshift-provider-cert-plugin/report-progress.sh
+++ b/tools/openshift-provider-cert-plugin/report-progress.sh
@@ -122,7 +122,6 @@ watch_dependency_done() {
             }"
             os_log_info_local "Sending report payload [dep-checker]: ${body}"
             curl -s "${PROGRESS_URL}" -d "${body}"
-
             # Timeout checker
             ## 1. Dont block by long running plugins (only non-updated)
             ## Timeout checks will increase only when previous jobs got stuck,
@@ -135,6 +134,12 @@ watch_dependency_done() {
             fi
             # dont run timeouts for blockers plugins
             if [[ "${blocker_msg}" =~ "status=blocked-by" ]]; then
+                timeout_checks=0
+                sleep 10
+                continue
+            fi
+            # dont run timeouts for if blocker is waiting
+            if [[ "${blocker_msg}" =~ "status=waiting-for" ]] && [[ "${state_blocking}" =~ "blocked-by" ]]; then
                 timeout_checks=0
                 sleep 10
                 continue

--- a/tools/openshift-provider-cert-plugin/wait-plugin.sh
+++ b/tools/openshift-provider-cert-plugin/wait-plugin.sh
@@ -24,8 +24,8 @@ if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
     done
 
     os_log_info_local "Resource(s) ready! Waiting for Level[${CERT_LEVEL:-}]'s plugins be completed..."
-    for plugin_name in "${PLUGIN_BLOCKED_BY[@]}"; do
-        os_log_info_local "Waiting 'completed' condition for pod: ${plugin_name}"
+    for bl_plugin_name in "${PLUGIN_BLOCKED_BY[@]}"; do
+        os_log_info_local "Waiting 'completed' condition for pod: ${bl_plugin_name}"
         
         # Wait until sonobuoy job is completed
         timeout_checks=0
@@ -33,12 +33,12 @@ if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
         last_count=0
         while true;
         do
-            plugin_status=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.status // \"\"" "${STATUS_FILE}")
+            plugin_status=$(jq -r ".plugins[] | select (.plugin == \"${bl_plugin_name}\" ) |.status // \"\"" "${STATUS_FILE}")
 
-            os_log_info_local "Plugin[${plugin_name}] with status[${plugin_status}]..."
+            os_log_info_local "Plugin[${bl_plugin_name}] with status[${plugin_status}]..."
             os_log_info_local "$(cat "${STATUS_FILE}")"
             if [[ "${plugin_status}" == "complete" ]]; then
-                os_log_info_local "Plugin[${plugin_name}] with status[${plugin_status}] is completed!"
+                os_log_info_local "Plugin[${bl_plugin_name}] with status[${plugin_status}] is completed!"
                 break
             fi
 
@@ -47,19 +47,21 @@ if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
             ## Timeout checks will increase only when previous jobs got stuck,
             ## otherwise it will be reset. It can avoid the plugin run infinitely,
             ## also avoid to set low timeouts for 'unknown' exec time on dependencies.
-            count=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.progress.completed // 0" "${STATUS_FILE}")
+            count=$(jq -r ".plugins[] | select (.plugin == \"${bl_plugin_name}\" ) |.progress.completed // 0" "${STATUS_FILE}")
             if [[ ${count} -gt ${last_count} ]]; then
                 timeout_checks=0
                 sleep 10
                 continue
             fi
             ## 2. Dont get stuck for blocked plugins (which is already waiting for deps)
-            blocker_msg=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.progress.msg // \"\"" "${STATUS_FILE}")
+            blocker_msg=$(jq -r ".plugins[] | select (.plugin == \"${bl_plugin_name}\" ) |.progress.msg // \"\"" "${STATUS_FILE}")
+            current_msg=$(jq -r ".plugins[] | select (.plugin == \"${PLUGIN_NAME}\" ) |.progress.msg // \"\"" "${STATUS_FILE}")
             if [[ "${blocker_msg}" =~ "status=blocked-by" ]]; then
                 timeout_checks=0
                 sleep 10
                 continue
-            elif [[ "${blocker_msg}" =~ "status=waiting-for" ]]; then
+            ## Should wait for blocker timeout (then !waiting-for state) to start timeout count
+            elif [[ "${blocker_msg}" =~ "status=waiting-for" ]] && [[ "${current_msg}" =~ "status=blocked-by" ]]; then
                 timeout_checks=0
                 sleep 10
                 continue
@@ -67,10 +69,10 @@ if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
             last_count=${count}
             timeout_checks=$(( timeout_checks + 1 ))
             if [[ ${timeout_checks} -eq ${timeout_count} ]]; then
-                os_log_info_local "Timeout waiting condition 'complete' for plugin[${plugin_name}]."
+                os_log_info_local "Timeout waiting condition 'complete' for plugin[${bl_plugin_name}]."
                 exit 1
             fi
-            os_log_info_local "Waiting 30s for Plugin[${plugin_name}]...[${timeout_checks}/${timeout_count}]"
+            os_log_info_local "Waiting 30s for Plugin[${bl_plugin_name}]...[${timeout_checks}/${timeout_count}]"
             sleep 30
         done
     done


### PR DESCRIPTION
**Bug**: The `report-progress` component was counting the blocked plugin timeout.

**Cause**: the timeout count was created to make sure the blocked plugin (states: `waiting-for` and `blocked-by`) will not be stuck forever. The problem is when the N-1 plugin is already blocked, it should not count timeout as it does not know how long to wait to finish. So the idea is to keep the timeout counter for plugins in which N-1 is not blocked (this change), and the progress counter is not updating [`progress/total`] (implementation already covered)


- T0) timeout count `[17/100]`
```
Fri Apr  8 10:11:50 -03 2022> Global Status: running                                                                                                                                            
JOB_NAME                       | STATUS     | RESULTS    | PROGRESS                  | MESSAGE                                                                                                  
openshift-kube-conformance     | running    |            | 205/345 (0 failures)      | status=running                                                                                           
openshift-provider-cert-level1 | running    |            | 0/81 (0 failures)         | status=waiting-for=openshift-kube-conformance=(0/-152/0)=[0/100]                                         
openshift-provider-cert-level2 | running    |            | 0/17 (0 failures)         | status=blocked-by=openshift-provider-cert-level1=(0/-81/0)=[17/100] 
```

- T1) timeout count `[19/100]`
```
Fri Apr  8 10:12:17 -03 2022> Global Status: running                                                                                                                                            
JOB_NAME                       | STATUS     | RESULTS    | PROGRESS                  | MESSAGE                                                                                                  
openshift-kube-conformance     | running    |            | 230/345 (0 failures)      | status=running                                                                                           
openshift-provider-cert-level1 | running    |            | 0/81 (0 failures)         | status=waiting-for=openshift-kube-conformance=(0/-126/0)=[0/100]                                         
openshift-provider-cert-level2 | running    |            | 0/17 (0 failures)         | status=blocked-by=openshift-provider-cert-level1=(0/-81/0)=[19/100]  
```