### PR TITLE
fix(plugin-cert): force failed junit when exec crashes

### DIFF
--- a/tools/openshift-provider-cert-plugin/executor.sh
+++ b/tools/openshift-provider-cert-plugin/executor.sh
@@ -41,6 +41,12 @@ if [[ -n "${CERT_TEST_FILE:-}" ]]; then
     else
         os_log_info "the file provided has no tests. Sending progress and finish executor...";
         echo "(0/0/0)" > "${RESULTS_PIPE}"
+
+        res_file="${RESULTS_DIR}/junit_empty_e2e_$(date +%Y%m%d-%H%M%S).xml"
+        os_log_info "Creating empty Junit result file [${res_file}]"
+        cat << EOF > "${res_file}"
+<testsuite name="openshift-tests" tests="1" skipped="0" failures="0" time="1.0"><property name="TestVersion" value="v4.1.0-4964-g555da83"></property><testcase name="[conformance] empty test list: ${CERT_TEST_FILE} has no tests to run" time="1.0"><failure message="">NoErrors</failure><system-out>stdout</system-out></testcase></testsuite>
+EOF
     fi
 
 # Filter by string pattern from 'all' tests

--- a/tools/openshift-provider-cert-plugin/runner.sh
+++ b/tools/openshift-provider-cert-plugin/runner.sh
@@ -35,15 +35,14 @@ sig_handler_save_results() {
     os_log_info_local "Looking for junit result files..."
     junit_output="$(ls junit*.xml || true)";
 
-    # Create empty junit result file to avoid failures on report.
-    # It happens when tests file is empty.
-    # TODO(pre-release): review that strategy
+    # Create failed junit result file to avoid failures on report.
+    # It could happened when executor has crashed.
     if [[ -z "${junit_output}" ]]; then
         local res_file
-        res_file="junit_empty_e2e_$(date +%Y%m%d-%H%M%S).xml"
-        os_log_info_local "Creating empty Junit result file [${res_file}]"
+        res_file="junit_failed_e2e_$(date +%Y%m%d-%H%M%S).xml"
+        os_log_info_local "Creating failed Junit result file [${res_file}]"
         cat << EOF > "${res_file}"
-<testsuite name="openshift-tests" tests="0" skipped="0" failures="0" time="1"><property name="TestVersion" value="v4.1.0-4964-g555da83"></property></testsuite>
+<testsuite name="openshift-tests" tests="1" skipped="0" failures="1" time="1.0"><property name="TestVersion" value="v4.1.0-4964-g555da83"></property><testcase name="[conformance] fallback error: possible that openshift-tests has crashed" time="1.0"><failure message="">errors</failure><system-out>stdout</system-out></testcase></testsuite>
 EOF
         junit_output=$(ls junit*.xml);
     fi


### PR DESCRIPTION
Creating the fake failed junit when the plugin crashes. It is happening when there's no 
enough resources to run the conformance tests.

A workaround that is used to fix this is to scale the compute machines to 5 (from default IPI on AWS). 

**DETAILS**

Currently, the 'empty' JUnit file is created when the plugin there's no tests to run. This PR creates
(1) an empty file for an empty list of tests, improving the description introducing with an item describing
that there are no tests to run, alongside (2) adding a failed item when JUnit file was not detected (when
the executor has crashed).

The executor expects to `openshift-tests` utility creates the JUnit files, but it seems to be buffered in
memory and lost when it crashes, unfortunately, the entire execution has been lost too. It's
possible to create a local list when processing the pipe from the utility on the report-progress component,
but it could be more complex to create parsers post-executor. For now, let's force the plugin to fail without
details considering that it does not matter as the execution has not finished.

**STEPS TO REPRODUCE**
- `run -w`
- Check the progress for the inconsistent counter (`302/345`) in plugin with `complete` status
```
Fri Apr 29 16:42:55 -03 2022> Global Status: running
JOB_NAME                       | STATUS     | RESULTS    | PROGRESS                  | MESSAGE                                           
openshift-kube-conformance     | complete   |            | 302/345 (0 failures)      | waiting post-processor...                         
openshift-provider-cert-level1 | complete   |            | 81/81 (0 failures)        | waiting post-processor...                         
openshift-provider-cert-level2 | complete   |            | 17/17 (0 failures)        | waiting post-processor...                         
openshift-provider-cert-level3 | running    |            | 0/0 (0 failures)          | status=running   
```
- Check the results after the Sonobuoy has processed the Junits:
```
Fri Apr 29 16:43:09 -03 2022> Global Status: post-processing
JOB_NAME                       | STATUS     | RESULTS    | PROGRESS                  | MESSAGE                                           
openshift-kube-conformance     | complete   | passed     | 302/345 (0 failures)      | Total tests processed: 1 (1 pass / 0 failed)      
openshift-provider-cert-level1 | complete   | failed     | 81/81 (0 failures)        | Total tests processed: 84 (83 pass / 1 failed)    
openshift-provider-cert-level2 | complete   | failed     | 17/17 (0 failures)        | Total tests processed: 20 (19 pass / 1 failed)    
openshift-provider-cert-level3 | complete   | passed     | 0/0 (0 failures)          | Total tests processed: 1 (1 pass / 0 failed)      

Fri Apr 29 16:43:09 -03 2022 #> Jobs has finished.



Fri Apr 29 16:43:11 -03 2022> Global Status: post-processing
JOB_NAME                       | STATUS     | RESULTS    | PROCESSOR RESULTS                                 
openshift-kube-conformance     | complete   | passed     | Total tests processed: 1 (1 pass / 0 failed)      
openshift-provider-cert-level1 | complete   | failed     | Total tests processed: 84 (83 pass / 1 failed)    
openshift-provider-cert-level2 | complete   | failed     | Total tests processed: 20 (19 pass / 1 failed)    
openshift-provider-cert-level3 | complete   | passed     | Total tests processed: 1 (1 pass / 0 failed)      

```
